### PR TITLE
login_firstのincludeパス fix

### DIFF
--- a/login_first.php
+++ b/login_first.php
@@ -1,5 +1,5 @@
 <?php
-include("../../kotai_shikibetsu_number.php");
+include("kotai_shikibetsu_number.php");
 include("pdo.php");
 
 //$pdo = new PDO('mysql:host=localhost;dbname=tenkokko;charset=utf8','root','hogehoge');


### PR DESCRIPTION
# login_first.phpの変更点
- 個体識別番号を取得するincludeパスがおかしかったため修正
(変更後、tenko_mainPage.phpにもページ遷移するようになった)